### PR TITLE
Improve haproxy version parsing

### DIFF
--- a/lib/facter/haproxy_version.rb
+++ b/lib/facter/haproxy_version.rb
@@ -15,7 +15,7 @@ if Facter::Util::Resolution.which('haproxy')
     haproxy_version_cmd = 'haproxy -v 2>&1'
     haproxy_version_result = Facter::Util::Resolution.exec(haproxy_version_cmd)
     setcode do
-      haproxy_version_result.to_s.lines.first.strip.split(/HA-Proxy/)[1].strip.split(/version/)[1].strip.split(/((\d+\.){2,}\d+).*/)[1]
+      haproxy_version_result.to_s.lines.first.strip.split(/HA-?Proxy/)[1].strip.split(/version/)[1].strip.split(/((\d+\.){2,}\d+).*/)[1]
     end
   end
 end


### PR DESCRIPTION
Haproxy 2.4 has changed output on `haproxy -v` that does not pass regex:
```
HAProxy version 2.4.0-6cbbecf 2021/05/14 - https://haproxy.org/
Status: long-term supported branch - will stop receiving fixes around Q2 2026.
Known bugs: http://www.haproxy.org/bugs/bugs-2.4.0.html
```